### PR TITLE
Fix validation error for sessions without names

### DIFF
--- a/backend/models/ExamSession.js
+++ b/backend/models/ExamSession.js
@@ -3,8 +3,11 @@ const mongoose = require('mongoose');
 const examSessionSchema = new mongoose.Schema({
   name: {
     type: String,
-    required: true,
-    trim: true
+    trim: true,
+    default: function() {
+      // Provide a default name based on creation date
+      return `Exam Session - ${new Date().toLocaleDateString()}`;
+    }
   },
   exam: {
     type: mongoose.Schema.Types.ObjectId,
@@ -82,6 +85,28 @@ const examSessionSchema = new mongoose.Schema({
     type: Date,
     default: Date.now
   }
+});
+
+// Pre-save hook to ensure name exists
+examSessionSchema.pre('save', async function(next) {
+  // If name is missing, generate one from exam title or use default
+  if (!this.name) {
+    if (this.populated('exam')) {
+      this.name = `${this.exam.title} - Session`;
+    } else if (this.exam) {
+      // Populate exam to get title
+      const Exam = mongoose.model('Exam');
+      const exam = await Exam.findById(this.exam);
+      if (exam) {
+        this.name = `${exam.title} - Session`;
+      } else {
+        this.name = `Exam Session - ${new Date().toLocaleDateString()}`;
+      }
+    } else {
+      this.name = `Exam Session - ${new Date().toLocaleDateString()}`;
+    }
+  }
+  next();
 });
 
 module.exports = mongoose.model('ExamSession', examSessionSchema);


### PR DESCRIPTION
Critical Fix:

Problem:
- Timer updates failing with 'name is required' validation error
- Existing sessions in database don't have name field
- New required field breaks backward compatibility

Solution:
- Made name field not required in ExamSession schema
- Added default function to generate name if not provided
- Added pre-save hook to auto-generate names from exam title
- Ensures backward compatibility with existing sessions

Changes:
- Removed 'required: true' from name field
- Default: 'Exam Session - [date]'
- Pre-save hook checks if name is missing
- Auto-generates: '[Exam Title] - Session' from exam reference
- Falls back to date-based name if exam not available

This allows:
- New sessions: Provide name in API (still validated there)
- Old sessions: Auto-generate name on first update
- Timer updates: Work without validation errors
- Graceful handling of legacy data

Files Modified:
- backend/models/ExamSession.js - Schema and pre-save hook