### PR TITLE
Fix URL configuration for development environment

### DIFF
--- a/frontend/src/pages/ExamSession.jsx
+++ b/frontend/src/pages/ExamSession.jsx
@@ -78,7 +78,7 @@ export default function ExamSession() {
         const element = dicomElementRef.current
         cornerstone.enable(element)
 
-        const baseUrl = import.meta.env.VITE_API_URL || window.location.origin
+        const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:5000'
         const imageId = `wadouri:${baseUrl}/${currentImage.path}`
         const image = await cornerstone.loadImage(imageId)
         cornerstone.displayImage(element, image)
@@ -112,7 +112,7 @@ export default function ExamSession() {
   }
 
   const setupSocket = () => {
-    const socketUrl = import.meta.env.VITE_API_URL || window.location.origin
+    const socketUrl = import.meta.env.VITE_API_URL || 'http://localhost:5000'
     socketRef.current = io(socketUrl, {
       auth: { token }
     })


### PR DESCRIPTION
The previous cleanup used window.location.origin as fallback which broke Socket.IO and DICOM loading in development (would use :3000 instead of :5000).

Changes:
- Restore http://localhost:5000 as fallback for development
- Keep VITE_API_URL environment variable support for production
- Ensures socket connection and DICOM images work in dev environment
- Frontend proxy in vite.config.js still handles /api and /uploads routes

All critical features verified:
✅ Socket synchronization (examiner → student display sync) ✅ Thumbnail navigation (navigate-image socket events) ✅ DICOM image display (Cornerstone.js integration) ✅ All socket event handlers intact
✅ All socket emit events intact