### PR TITLE
Add case submission and management for examiners

### DIFF
--- a/backend/routes/cases.js
+++ b/backend/routes/cases.js
@@ -50,8 +50,8 @@ const upload = multer({
   limits: { fileSize: 50 * 1024 * 1024 } // 50MB limit
 });
 
-// Create new case
-router.post('/', authenticate, authorize('admin'), upload.array('images', 10), async (req, res) => {
+// Create new case - Allow both admins and examiners
+router.post('/', authenticate, authorize('admin', 'examiner'), upload.array('images', 10), async (req, res) => {
   try {
     const { title, clinicalHistory, discussionPoints } = req.body;
 
@@ -98,10 +98,17 @@ router.post('/', authenticate, authorize('admin'), upload.array('images', 10), a
   }
 });
 
-// Get all cases
+// Get all cases - Admins see all, examiners see only their own
 router.get('/', authenticate, async (req, res) => {
   try {
-    const cases = await Case.find()
+    let query = {};
+
+    // If user is an examiner (not admin), only show their own cases
+    if (req.userRole === 'examiner') {
+      query.createdBy = req.userId;
+    }
+
+    const cases = await Case.find(query)
       .populate('createdBy', 'firstName lastName email')
       .sort({ createdAt: -1 });
 
@@ -129,14 +136,19 @@ router.get('/:id', authenticate, async (req, res) => {
   }
 });
 
-// Update case
-router.put('/:id', authenticate, authorize('admin'), upload.array('newImages', 10), async (req, res) => {
+// Update case - Admins can edit all, examiners can edit only their own
+router.put('/:id', authenticate, authorize('admin', 'examiner'), upload.array('newImages', 10), async (req, res) => {
   try {
     const { title, clinicalHistory, discussionPoints, imageDescriptions } = req.body;
     const caseItem = await Case.findById(req.params.id);
 
     if (!caseItem) {
       return res.status(404).json({ message: 'Case not found' });
+    }
+
+    // Check if examiner is trying to edit someone else's case
+    if (req.userRole === 'examiner' && caseItem.createdBy.toString() !== req.userId) {
+      return res.status(403).json({ message: 'You can only edit cases you created' });
     }
 
     if (title) caseItem.title = title;
@@ -197,13 +209,18 @@ router.put('/:id', authenticate, authorize('admin'), upload.array('newImages', 1
   }
 });
 
-// Delete case
-router.delete('/:id', authenticate, authorize('admin'), async (req, res) => {
+// Delete case - Admins can delete all, examiners can delete only their own
+router.delete('/:id', authenticate, authorize('admin', 'examiner'), async (req, res) => {
   try {
     const caseItem = await Case.findById(req.params.id);
 
     if (!caseItem) {
       return res.status(404).json({ message: 'Case not found' });
+    }
+
+    // Check if examiner is trying to delete someone else's case
+    if (req.userRole === 'examiner' && caseItem.createdBy.toString() !== req.userId) {
+      return res.status(403).json({ message: 'You can only delete cases you created' });
     }
 
     // Delete associated images
@@ -222,13 +239,18 @@ router.delete('/:id', authenticate, authorize('admin'), async (req, res) => {
   }
 });
 
-// Delete specific image from case
-router.delete('/:id/images/:imageId', authenticate, authorize('admin'), async (req, res) => {
+// Delete specific image from case - Admins can delete all, examiners can delete only from their own cases
+router.delete('/:id/images/:imageId', authenticate, authorize('admin', 'examiner'), async (req, res) => {
   try {
     const caseItem = await Case.findById(req.params.id);
 
     if (!caseItem) {
       return res.status(404).json({ message: 'Case not found' });
+    }
+
+    // Check if examiner is trying to delete image from someone else's case
+    if (req.userRole === 'examiner' && caseItem.createdBy.toString() !== req.userId) {
+      return res.status(403).json({ message: 'You can only delete images from cases you created' });
     }
 
     const imageIndex = caseItem.images.findIndex(

--- a/frontend/src/components/examiner/ExaminerCaseManager.jsx
+++ b/frontend/src/components/examiner/ExaminerCaseManager.jsx
@@ -1,0 +1,601 @@
+import { useState, useEffect } from 'react'
+import { useDropzone } from 'react-dropzone'
+import axios from 'axios'
+
+export default function ExaminerCaseManager() {
+  const [cases, setCases] = useState([])
+  const [showCreateForm, setShowCreateForm] = useState(false)
+  const [editingCase, setEditingCase] = useState(null)
+  const [formData, setFormData] = useState({
+    title: '',
+    clinicalHistory: ''
+  })
+  const [selectedFiles, setSelectedFiles] = useState([])
+  const [imageDescriptions, setImageDescriptions] = useState({})
+  const [discussionPoints, setDiscussionPoints] = useState([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetchCases()
+  }, [])
+
+  const fetchCases = async () => {
+    try {
+      const response = await axios.get('/api/cases')
+      setCases(response.data.cases)
+    } catch (error) {
+      console.error('Error fetching cases:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const { getRootProps, getInputProps } = useDropzone({
+    accept: {
+      'image/*': ['.jpeg', '.jpg', '.png', '.gif', '.dcm']
+    },
+    onDrop: acceptedFiles => {
+      setSelectedFiles(prev => [...prev, ...acceptedFiles])
+    }
+  })
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+
+    if (!formData.title || !formData.clinicalHistory) {
+      alert('Please fill in all fields')
+      return
+    }
+
+    if (selectedFiles.length === 0) {
+      alert('Please upload at least one image')
+      return
+    }
+
+    const data = new FormData()
+    data.append('title', formData.title)
+    data.append('clinicalHistory', formData.clinicalHistory)
+    data.append('discussionPoints', JSON.stringify(discussionPoints))
+    selectedFiles.forEach(file => {
+      data.append('images', file)
+    })
+
+    try {
+      const response = await axios.post('/api/cases', data, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+      })
+      setCases([response.data.case, ...cases])
+      setFormData({ title: '', clinicalHistory: '' })
+      setSelectedFiles([])
+      setDiscussionPoints([])
+      setShowCreateForm(false)
+      alert('Case created successfully')
+    } catch (error) {
+      console.error('Error creating case:', error)
+      alert(error.response?.data?.message || 'Failed to create case')
+    }
+  }
+
+  const deleteCase = async (caseId) => {
+    if (!confirm('Are you sure you want to delete this case?')) return
+
+    try {
+      await axios.delete(`/api/cases/${caseId}`)
+      setCases(cases.filter(c => c._id !== caseId))
+    } catch (error) {
+      console.error('Error deleting case:', error)
+      alert(error.response?.data?.message || 'Failed to delete case')
+    }
+  }
+
+  const startEditCase = (caseItem) => {
+    setEditingCase(caseItem)
+    setFormData({
+      title: caseItem.title,
+      clinicalHistory: caseItem.clinicalHistory
+    })
+    setSelectedFiles([])
+
+    const descriptions = {}
+    caseItem.images.forEach(image => {
+      descriptions[image._id] = image.description || ''
+    })
+    setImageDescriptions(descriptions)
+
+    setDiscussionPoints(caseItem.discussionPoints || [])
+    setShowCreateForm(false)
+  }
+
+  const handleUpdate = async (e) => {
+    e.preventDefault()
+
+    if (!formData.title || !formData.clinicalHistory) {
+      alert('Please fill in all fields')
+      return
+    }
+
+    const data = new FormData()
+    data.append('title', formData.title)
+    data.append('clinicalHistory', formData.clinicalHistory)
+    data.append('discussionPoints', JSON.stringify(discussionPoints))
+    data.append('imageDescriptions', JSON.stringify(imageDescriptions))
+
+    selectedFiles.forEach(file => {
+      data.append('newImages', file)
+    })
+
+    try {
+      const response = await axios.put(`/api/cases/${editingCase._id}`, data, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+      })
+      setCases(cases.map(c => c._id === editingCase._id ? response.data.case : c))
+      setFormData({ title: '', clinicalHistory: '' })
+      setSelectedFiles([])
+      setImageDescriptions({})
+      setDiscussionPoints([])
+      setEditingCase(null)
+      alert('Case updated successfully')
+    } catch (error) {
+      console.error('Error updating case:', error)
+      alert(error.response?.data?.message || 'Failed to update case')
+    }
+  }
+
+  const cancelEdit = () => {
+    setEditingCase(null)
+    setFormData({ title: '', clinicalHistory: '' })
+    setSelectedFiles([])
+    setImageDescriptions({})
+    setDiscussionPoints([])
+  }
+
+  const addDiscussionPoint = () => {
+    setDiscussionPoints([...discussionPoints, { point: '', order: discussionPoints.length }])
+  }
+
+  const updateDiscussionPoint = (index, value) => {
+    const updated = [...discussionPoints]
+    updated[index].point = value
+    setDiscussionPoints(updated)
+  }
+
+  const removeDiscussionPoint = (index) => {
+    const updated = discussionPoints.filter((_, i) => i !== index)
+    updated.forEach((point, i) => {
+      point.order = i
+    })
+    setDiscussionPoints(updated)
+  }
+
+  const moveDiscussionPoint = (index, direction) => {
+    const newIndex = direction === 'up' ? index - 1 : index + 1
+    if (newIndex < 0 || newIndex >= discussionPoints.length) return
+
+    const updated = [...discussionPoints]
+    const [removed] = updated.splice(index, 1)
+    updated.splice(newIndex, 0, removed)
+
+    updated.forEach((point, i) => {
+      point.order = i
+    })
+
+    setDiscussionPoints(updated)
+  }
+
+  const deleteImage = async (caseId, imageId) => {
+    if (!confirm('Are you sure you want to delete this image?')) return
+
+    try {
+      await axios.delete(`/api/cases/${caseId}/images/${imageId}`)
+      setCases(cases.map(c => {
+        if (c._id === caseId) {
+          return {
+            ...c,
+            images: c.images.filter(img => img._id !== imageId)
+          }
+        }
+        return c
+      }))
+
+      if (editingCase && editingCase._id === caseId) {
+        setEditingCase({
+          ...editingCase,
+          images: editingCase.images.filter(img => img._id !== imageId)
+        })
+      }
+    } catch (error) {
+      console.error('Error deleting image:', error)
+      alert(error.response?.data?.message || 'Failed to delete image')
+    }
+  }
+
+  const removeFile = (index) => {
+    setSelectedFiles(selectedFiles.filter((_, i) => i !== index))
+  }
+
+  if (loading) {
+    return <div className="text-center py-8">Loading cases...</div>
+  }
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-2xl font-bold">My Cases</h2>
+        <button
+          onClick={() => {
+            setShowCreateForm(!showCreateForm)
+            setEditingCase(null)
+          }}
+          className="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+        >
+          {showCreateForm ? 'Cancel' : 'Create New Case'}
+        </button>
+      </div>
+
+      {editingCase && (
+        <div className="bg-white shadow rounded-lg p-6 mb-6">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="text-lg font-semibold">Edit Case</h3>
+            <button
+              onClick={cancelEdit}
+              className="text-gray-600 hover:text-gray-800"
+            >
+              Cancel
+            </button>
+          </div>
+          <form onSubmit={handleUpdate} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Case Title
+              </label>
+              <input
+                type="text"
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                placeholder="e.g., Acute Appendicitis"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Clinical History
+              </label>
+              <textarea
+                value={formData.clinicalHistory}
+                onChange={(e) => setFormData({ ...formData, clinicalHistory: e.target.value })}
+                rows="4"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                placeholder="Enter detailed clinical history..."
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Current Images ({editingCase.images.length})
+              </label>
+              <div className="space-y-4">
+                {editingCase.images.map((image) => (
+                  <div key={image._id} className="border border-gray-200 rounded-lg p-4 bg-gray-50">
+                    <div className="flex gap-4">
+                      <div className="relative group flex-shrink-0">
+                        <img
+                          src={`/${image.path}`}
+                          alt={image.originalName}
+                          className="w-32 h-32 object-cover rounded border"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => deleteImage(editingCase._id, image._id)}
+                          className="absolute top-1 right-1 bg-red-600 text-white px-2 py-1 rounded text-xs hover:bg-red-700 opacity-0 group-hover:opacity-100 transition"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                      <div className="flex-1">
+                        <p className="text-sm font-medium text-gray-700 mb-2">{image.originalName}</p>
+                        <label className="block text-xs font-medium text-gray-600 mb-1">
+                          Image Description:
+                        </label>
+                        <textarea
+                          value={imageDescriptions[image._id] || ''}
+                          onChange={(e) => setImageDescriptions({
+                            ...imageDescriptions,
+                            [image._id]: e.target.value
+                          })}
+                          rows="2"
+                          className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                          placeholder="Add notes or annotations for this image..."
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Add New Images (optional)
+              </label>
+              <div
+                {...getRootProps()}
+                className="border-2 border-dashed border-gray-300 rounded-md p-6 text-center cursor-pointer hover:border-indigo-500"
+              >
+                <input {...getInputProps()} />
+                <p className="text-gray-600">
+                  Drag & drop images here, or click to select files
+                </p>
+                <p className="text-sm text-gray-500 mt-1">
+                  Supports: JPEG, PNG, GIF, DICOM
+                </p>
+              </div>
+
+              {selectedFiles.length > 0 && (
+                <div className="mt-4 space-y-2">
+                  <p className="text-sm font-medium">New files to add ({selectedFiles.length}):</p>
+                  {selectedFiles.map((file, index) => (
+                    <div key={index} className="flex items-center justify-between bg-gray-50 p-2 rounded">
+                      <span className="text-sm">{file.name}</span>
+                      <button
+                        type="button"
+                        onClick={() => removeFile(index)}
+                        className="text-red-600 hover:text-red-800 text-sm"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <div className="flex justify-between items-center mb-2">
+                <label className="block text-sm font-medium text-gray-700">
+                  Discussion Points ({discussionPoints.length})
+                </label>
+                <button
+                  type="button"
+                  onClick={addDiscussionPoint}
+                  className="px-3 py-1 text-sm bg-green-600 text-white rounded hover:bg-green-700"
+                >
+                  + Add Point
+                </button>
+              </div>
+
+              {discussionPoints.length === 0 ? (
+                <p className="text-sm text-gray-500 italic p-4 bg-gray-50 rounded border border-gray-200">
+                  No discussion points yet. Add structured points for reference during exams.
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {discussionPoints.map((point, index) => (
+                    <div key={index} className="flex items-start gap-2 bg-gray-50 p-3 rounded border border-gray-200">
+                      <div className="flex flex-col gap-1">
+                        <button
+                          type="button"
+                          onClick={() => moveDiscussionPoint(index, 'up')}
+                          disabled={index === 0}
+                          className={`text-xs ${index === 0 ? 'text-gray-300' : 'text-gray-600 hover:text-indigo-600'}`}
+                        >
+                          ▲
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => moveDiscussionPoint(index, 'down')}
+                          disabled={index === discussionPoints.length - 1}
+                          className={`text-xs ${index === discussionPoints.length - 1 ? 'text-gray-300' : 'text-gray-600 hover:text-indigo-600'}`}
+                        >
+                          ▼
+                        </button>
+                      </div>
+                      <span className="font-semibold text-gray-700 mt-2">{index + 1}.</span>
+                      <textarea
+                        value={point.point}
+                        onChange={(e) => updateDiscussionPoint(index, e.target.value)}
+                        rows="2"
+                        className="flex-1 px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                        placeholder="Enter discussion point..."
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeDiscussionPoint(index)}
+                        className="text-red-600 hover:text-red-800 text-sm mt-2"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <button
+              type="submit"
+              className="w-full px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+            >
+              Update Case
+            </button>
+          </form>
+        </div>
+      )}
+
+      {showCreateForm && (
+        <div className="bg-white shadow rounded-lg p-6 mb-6">
+          <h3 className="text-lg font-semibold mb-4">Create New Case</h3>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Case Title
+              </label>
+              <input
+                type="text"
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                placeholder="e.g., Acute Appendicitis"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Clinical History
+              </label>
+              <textarea
+                value={formData.clinicalHistory}
+                onChange={(e) => setFormData({ ...formData, clinicalHistory: e.target.value })}
+                rows="4"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                placeholder="Enter detailed clinical history..."
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Images
+              </label>
+              <div
+                {...getRootProps()}
+                className="border-2 border-dashed border-gray-300 rounded-md p-6 text-center cursor-pointer hover:border-indigo-500"
+              >
+                <input {...getInputProps()} />
+                <p className="text-gray-600">
+                  Drag & drop images here, or click to select files
+                </p>
+                <p className="text-sm text-gray-500 mt-1">
+                  Supports: JPEG, PNG, GIF, DICOM
+                </p>
+              </div>
+
+              {selectedFiles.length > 0 && (
+                <div className="mt-4 space-y-2">
+                  <p className="text-sm font-medium">Selected files ({selectedFiles.length}):</p>
+                  {selectedFiles.map((file, index) => (
+                    <div key={index} className="flex items-center justify-between bg-gray-50 p-2 rounded">
+                      <span className="text-sm">{file.name}</span>
+                      <button
+                        type="button"
+                        onClick={() => removeFile(index)}
+                        className="text-red-600 hover:text-red-800 text-sm"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <div className="flex justify-between items-center mb-2">
+                <label className="block text-sm font-medium text-gray-700">
+                  Discussion Points ({discussionPoints.length})
+                </label>
+                <button
+                  type="button"
+                  onClick={addDiscussionPoint}
+                  className="px-3 py-1 text-sm bg-green-600 text-white rounded hover:bg-green-700"
+                >
+                  + Add Point
+                </button>
+              </div>
+
+              {discussionPoints.length > 0 && (
+                <div className="space-y-2">
+                  {discussionPoints.map((point, index) => (
+                    <div key={index} className="flex items-start gap-2 bg-gray-50 p-3 rounded border border-gray-200">
+                      <span className="font-semibold text-gray-700 mt-2">{index + 1}.</span>
+                      <textarea
+                        value={point.point}
+                        onChange={(e) => updateDiscussionPoint(index, e.target.value)}
+                        rows="2"
+                        className="flex-1 px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                        placeholder="Enter discussion point..."
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeDiscussionPoint(index)}
+                        className="text-red-600 hover:text-red-800 text-sm mt-2"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <button
+              type="submit"
+              className="w-full px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+            >
+              Create Case
+            </button>
+          </form>
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {cases.length === 0 ? (
+          <p className="text-gray-500 text-center py-8">No cases yet. Create one above.</p>
+        ) : (
+          cases.map(caseItem => (
+            <div key={caseItem._id} className="bg-white shadow rounded-lg p-6">
+              <div className="flex justify-between items-start mb-4">
+                <div className="flex-1">
+                  <h3 className="text-lg font-semibold">{caseItem.title}</h3>
+                  <p className="text-sm text-gray-600 mt-1">{caseItem.clinicalHistory}</p>
+                  {caseItem.discussionPoints && caseItem.discussionPoints.length > 0 && (
+                    <div className="mt-3">
+                      <p className="text-xs font-semibold text-gray-700 mb-1">Discussion Points:</p>
+                      <ul className="list-disc list-inside text-xs text-gray-600">
+                        {caseItem.discussionPoints.slice(0, 3).map((dp, idx) => (
+                          <li key={idx}>{dp.point}</li>
+                        ))}
+                        {caseItem.discussionPoints.length > 3 && (
+                          <li className="text-gray-500">... and {caseItem.discussionPoints.length - 3} more</li>
+                        )}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => startEditCase(caseItem)}
+                    className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => deleteCase(caseItem._id)}
+                    className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 text-sm"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-4 gap-4">
+                {caseItem.images.map((image, index) => (
+                  <div key={index} className="relative group">
+                    <img
+                      src={`/${image.path}`}
+                      alt={image.originalName}
+                      className="w-full h-32 object-cover rounded border"
+                    />
+                    <p className="text-xs text-gray-600 mt-1 truncate">{image.originalName}</p>
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-4 text-sm text-gray-500">
+                Created: {new Date(caseItem.createdAt).toLocaleDateString()}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/ExamSession.jsx
+++ b/frontend/src/pages/ExamSession.jsx
@@ -234,8 +234,13 @@ export default function ExamSession() {
 
     setCurrentCase(caseData)
 
-    if (caseData.images && caseData.images[imageIndex]) {
-      setCurrentImage(caseData.images[imageIndex])
+    // imageIndex 0 is reserved for history view
+    // Actual images start at index 1
+    if (imageIndex > 0 && caseData.images && caseData.images[imageIndex - 1]) {
+      setCurrentImage(caseData.images[imageIndex - 1])
+    } else if (imageIndex === 0) {
+      // History view - no image to set
+      setCurrentImage(null)
     } else {
       console.error('updateCurrentDisplay: image not found', {
         imageIndex,
@@ -285,7 +290,10 @@ export default function ExamSession() {
   const nextImage = () => {
     if (!session?.exam?.cases || !currentCase) return
 
-    if (currentImageIndex < currentCase.images.length - 1) {
+    // imageIndex 0 = history, images start at index 1
+    const maxImageIndex = currentCase.images.length // last image is at length (since 0 is history)
+
+    if (currentImageIndex < maxImageIndex) {
       navigateToImage(currentCaseIndex, currentImageIndex + 1)
     } else if (currentCaseIndex < session.exam.cases.length - 1) {
       navigateToImage(currentCaseIndex + 1, 0)
@@ -299,7 +307,8 @@ export default function ExamSession() {
       navigateToImage(currentCaseIndex, currentImageIndex - 1)
     } else if (currentCaseIndex > 0) {
       const prevCase = session.exam.cases[currentCaseIndex - 1]
-      navigateToImage(currentCaseIndex - 1, prevCase.images.length - 1)
+      // Navigate to last image of previous case (length, not length-1, since 0 is history)
+      navigateToImage(currentCaseIndex - 1, prevCase.images.length)
     }
   }
 
@@ -505,7 +514,7 @@ export default function ExamSession() {
                         <div className="text-center mt-4">
                           <p className="text-gray-400">
                             Case {currentCaseIndex + 1} / {session.exam.cases.length} -
-                            Image {currentImageIndex + 1} / {currentCase?.images.length}
+                            Image {currentImageIndex} / {currentCase?.images.length}
                           </p>
                           <p className="text-sm text-blue-400 mt-2">DICOM Image</p>
                           {currentImage.description && (
@@ -525,7 +534,7 @@ export default function ExamSession() {
                         <div className="text-center mt-4">
                           <p className="text-gray-400">
                             Case {currentCaseIndex + 1} / {session.exam.cases.length} -
-                            Image {currentImageIndex + 1} / {currentCase?.images.length}
+                            Image {currentImageIndex} / {currentCase?.images.length}
                           </p>
                           {currentImage.description && (
                             <p className="mt-2 text-gray-500 text-sm italic">
@@ -577,9 +586,9 @@ export default function ExamSession() {
                 {currentCase.images.map((img, idx) => (
                   <button
                     key={idx}
-                    onClick={() => navigateToImage(currentCaseIndex, idx)}
+                    onClick={() => navigateToImage(currentCaseIndex, idx + 1)}
                     className={`relative aspect-square rounded-lg overflow-hidden transition-all transform hover:scale-105 ${
-                      viewMode === 'image' && currentImageIndex === idx
+                      viewMode === 'image' && currentImageIndex === idx + 1
                         ? 'ring-4 ring-blue-500 shadow-lg shadow-blue-500/50'
                         : 'ring-1 ring-gray-600 hover:ring-2 hover:ring-gray-400'
                     }`}

--- a/frontend/src/pages/ExaminerDashboard.jsx
+++ b/frontend/src/pages/ExaminerDashboard.jsx
@@ -2,11 +2,13 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import axios from 'axios'
 import { useAuth } from '../context/AuthContext'
+import ExaminerCaseManager from '../components/examiner/ExaminerCaseManager'
 
 export default function ExaminerDashboard() {
   const { user, logout } = useAuth()
   const [sessions, setSessions] = useState([])
   const [loading, setLoading] = useState(true)
+  const [activeTab, setActiveTab] = useState('sessions')
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -68,13 +70,43 @@ export default function ExaminerDashboard() {
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="bg-white shadow rounded-lg p-6">
-          <div className="flex justify-between items-center mb-6">
-            <h2 className="text-lg font-semibold">Your Assigned Exam Sessions</h2>
-            <div className="text-sm text-gray-500">
-              Sessions are created and assigned by administrators
-            </div>
+        {/* Tabs */}
+        <div className="mb-6">
+          <div className="border-b border-gray-200">
+            <nav className="-mb-px flex space-x-8">
+              <button
+                onClick={() => setActiveTab('sessions')}
+                className={`${
+                  activeTab === 'sessions'
+                    ? 'border-indigo-500 text-indigo-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}
+              >
+                Exam Sessions
+              </button>
+              <button
+                onClick={() => setActiveTab('cases')}
+                className={`${
+                  activeTab === 'cases'
+                    ? 'border-indigo-500 text-indigo-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}
+              >
+                My Cases
+              </button>
+            </nav>
           </div>
+        </div>
+
+        {/* Sessions Tab */}
+        {activeTab === 'sessions' && (
+          <div className="bg-white shadow rounded-lg p-6">
+            <div className="flex justify-between items-center mb-6">
+              <h2 className="text-lg font-semibold">Your Assigned Exam Sessions</h2>
+              <div className="text-sm text-gray-500">
+                Sessions are created and assigned by administrators
+              </div>
+            </div>
 
           {sessions.length === 0 ? (
             <div className="text-center py-12">
@@ -181,7 +213,15 @@ export default function ExaminerDashboard() {
               ))}
             </div>
           )}
-        </div>
+          </div>
+        )}
+
+        {/* Cases Tab */}
+        {activeTab === 'cases' && (
+          <div className="bg-white shadow rounded-lg p-6">
+            <ExaminerCaseManager />
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
- Fix thumbnail navigation: separate history (index 0) from image thumbnails (index 1+)
- Update case routes to allow examiners to create, edit, and delete their own cases
- Add ExaminerCaseManager component for case management with full CRUD operations
- Update ExaminerDashboard with tabs for Sessions and Cases
- Examiners can now submit cases with images, clinical history, and discussion points
- Examiners can view and edit only their own cases
- Fixed issue where clicking first thumbnail showed history instead of first image