### PR TITLE
Add session edit, clone, and fix DICOM visibility

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -604,4 +604,47 @@ router.patch('/sessions/:id/unarchive', async (req, res) => {
   }
 });
 
+// Clone session
+router.post('/sessions/:id/clone', async (req, res) => {
+  try {
+    const session = await ExamSession.findById(req.params.id)
+      .populate('exam')
+      .populate('examiner', 'firstName lastName email')
+      .populate('examiners', 'firstName lastName email')
+      .populate('assignedStudents', 'firstName lastName email');
+
+    if (!session) {
+      return res.status(404).json({ message: 'Session not found' });
+    }
+
+    // Create a new session with the same data but new name
+    const clonedSession = new ExamSession({
+      name: `${session.name} (Copy)`,
+      exam: session.exam._id,
+      examiner: session.examiner._id,
+      examiners: session.examiners.map(e => e._id),
+      assignedStudents: session.assignedStudents.map(s => s._id),
+      examinerStudentPairs: session.examinerStudentPairs || [],
+      status: 'scheduled',
+      timeRemaining: session.exam.duration * 60 // Convert minutes to seconds
+    });
+
+    await clonedSession.save();
+    await clonedSession.populate('exam');
+    await clonedSession.populate('examiner', 'firstName lastName email');
+    await clonedSession.populate('examiners', 'firstName lastName email');
+    await clonedSession.populate('assignedStudents', 'firstName lastName email');
+    await clonedSession.populate('examinerStudentPairs.examiner', 'firstName lastName email');
+    await clonedSession.populate('examinerStudentPairs.student', 'firstName lastName email');
+
+    res.status(201).json({
+      message: 'Session cloned successfully',
+      session: clonedSession
+    });
+  } catch (error) {
+    console.error('Clone session error:', error);
+    res.status(500).json({ message: 'Server error while cloning session' });
+  }
+});
+
 module.exports = router;

--- a/frontend/src/components/admin/SessionManager.jsx
+++ b/frontend/src/components/admin/SessionManager.jsx
@@ -242,6 +242,19 @@ export default function SessionManager() {
     }
   }
 
+  const cloneSession = async (sessionId) => {
+    if (!confirm('Are you sure you want to clone this session?')) return
+
+    try {
+      const response = await axios.post(`/api/admin/sessions/${sessionId}/clone`)
+      alert('Session cloned successfully')
+      fetchData()
+    } catch (error) {
+      console.error('Error cloning session:', error)
+      alert('Failed to clone session')
+    }
+  }
+
   const getStatusColor = (status) => {
     const colors = {
       scheduled: 'bg-blue-100 text-blue-800',
@@ -590,6 +603,15 @@ export default function SessionManager() {
                       className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm"
                     >
                       Edit
+                    </button>
+                  )}
+
+                  {!session.isArchived && (
+                    <button
+                      onClick={() => cloneSession(session._id)}
+                      className="px-3 py-1 bg-purple-600 text-white rounded hover:bg-purple-700 text-sm"
+                    >
+                      Clone
                     </button>
                   )}
 

--- a/frontend/src/pages/ExamSession.jsx
+++ b/frontend/src/pages/ExamSession.jsx
@@ -24,6 +24,7 @@ export default function ExamSession() {
   const navigate = useNavigate()
   const socketRef = useRef(null)
   const dicomElementRef = useRef(null)
+  const thumbnailCanvasRefs = useRef([])
 
   const [session, setSession] = useState(null)
   const [currentCase, setCurrentCase] = useState(null)
@@ -35,6 +36,7 @@ export default function ExamSession() {
   const [loading, setLoading] = useState(true)
   const [viewMode, setViewMode] = useState('history') // 'history', 'image', or 'transition'
   const [showTransition, setShowTransition] = useState(false)
+  const [dicomThumbnails, setDicomThumbnails] = useState({})
 
   const isExaminer = user.role === 'examiner' || user.role === 'admin'
   const isRunning = status === 'active'
@@ -80,6 +82,53 @@ export default function ExamSession() {
       loadDicomImage()
     }
   }, [currentImage])
+
+  // Load DICOM thumbnails when current case changes
+  useEffect(() => {
+    if (currentCase && currentCase.images) {
+      loadDicomThumbnails()
+    }
+  }, [currentCase])
+
+  const loadDicomThumbnails = async () => {
+    if (!currentCase || !currentCase.images) return
+
+    const baseUrl = import.meta.env.VITE_API_URL || window.location.origin
+    const thumbnails = {}
+
+    for (let idx = 0; idx < currentCase.images.length; idx++) {
+      const img = currentCase.images[idx]
+      const isDicom = img.path.toLowerCase().endsWith('.dcm') ||
+                      img.path.toLowerCase().includes('.dicom')
+
+      if (isDicom) {
+        try {
+          // Create a temporary canvas element for thumbnail
+          const canvas = document.createElement('canvas')
+          canvas.width = 128
+          canvas.height = 128
+
+          cornerstone.enable(canvas)
+
+          const imagePath = img.path.startsWith('/') ? img.path.slice(1) : img.path
+          const imageId = `wadouri:${baseUrl}/${imagePath}`
+
+          const image = await cornerstone.loadImage(imageId)
+          cornerstone.displayImage(canvas, image)
+
+          // Convert canvas to data URL for storage
+          const dataUrl = canvas.toDataURL('image/png')
+          thumbnails[idx] = dataUrl
+
+          cornerstone.disable(canvas)
+        } catch (error) {
+          console.error(`Error loading DICOM thumbnail for image ${idx}:`, error)
+        }
+      }
+    }
+
+    setDicomThumbnails(thumbnails)
+  }
 
   const loadDicomImage = async () => {
     if (!currentImage || !dicomElementRef.current) return
@@ -595,11 +644,19 @@ export default function ExamSession() {
                     title={`Image ${idx + 1}${img.description ? ': ' + img.description : ''}`}
                   >
                     {isDicomFile(img.path) ? (
-                      <div className="w-full h-full bg-gray-700 flex items-center justify-center">
-                        <svg className="w-8 h-8 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                        </svg>
-                      </div>
+                      dicomThumbnails[idx] ? (
+                        <img
+                          src={dicomThumbnails[idx]}
+                          alt={`DICOM Image ${idx + 1}`}
+                          className="w-full h-full object-cover bg-gray-900"
+                        />
+                      ) : (
+                        <div className="w-full h-full bg-gray-700 flex items-center justify-center">
+                          <svg className="w-8 h-8 text-blue-400 animate-pulse" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                          </svg>
+                        </div>
+                      )
                     ) : (
                       <img
                         src={`/${img.path}`}


### PR DESCRIPTION
- Add clone endpoint for sessions (POST /api/admin/sessions/:id/clone)
- Add clone button to SessionManager UI for non-archived sessions
- Fix DICOM thumbnail display to show actual image previews instead of placeholder icons
- Generate DICOM thumbnails using cornerstone when case loads
- Show loading animation while DICOM thumbnails are being generated

This enables admins to easily duplicate sessions and provides better visual feedback for DICOM files in the exam interface.