### PR TITLE
Fix NaN values in DICOM metadata extraction

### DIFF
--- a/backend/utils/dicomUtils.js
+++ b/backend/utils/dicomUtils.js
@@ -23,10 +23,13 @@ function extractDicomMetadata(filePath) {
       }
     };
 
-    const getTagNumber = (tag, defaultValue = 0) => {
+    const getTagNumber = (tag, defaultValue = undefined) => {
       try {
         const value = dataSet.string(tag);
-        return value ? parseInt(value, 10) : defaultValue;
+        if (!value) return defaultValue;
+        const parsed = parseInt(value, 10);
+        // Return defaultValue if parsing results in NaN
+        return isNaN(parsed) ? defaultValue : parsed;
       } catch (e) {
         return defaultValue;
       }


### PR DESCRIPTION
The getTagNumber helper was returning NaN when parseInt() failed to parse invalid or missing DICOM tag values. This caused MongoDB validation errors when saving cases with DICOM images.

Changes:
- Check for NaN after parseInt() and return default value instead
- Change default from 0 to undefined for optional fields
- Ensures rows/columns fields are omitted if invalid, not set to NaN

Fixes: CastError: Cast to Number failed for value "NaN"