### PR TITLE
Move collapsible case list from exam session to case manager

### DIFF
--- a/frontend/src/components/admin/CaseManager.jsx
+++ b/frontend/src/components/admin/CaseManager.jsx
@@ -16,6 +16,8 @@ export default function CaseManager() {
   const [imageDescriptions, setImageDescriptions] = useState({})
   const [discussionPoints, setDiscussionPoints] = useState([])
   const [loading, setLoading] = useState(true)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [expandedCases, setExpandedCases] = useState({})
 
   useEffect(() => {
     fetchCases()
@@ -258,28 +260,74 @@ export default function CaseManager() {
     }
   }
 
+  const toggleCaseExpansion = (caseId) => {
+    setExpandedCases(prev => ({
+      ...prev,
+      [caseId]: !prev[caseId]
+    }))
+  }
+
+  const filteredCases = cases.filter(caseItem => {
+    if (!searchQuery.trim()) return true
+
+    const query = searchQuery.toLowerCase()
+    const title = (caseItem.title || '').toLowerCase()
+    const history = (caseItem.clinicalHistory || '').toLowerCase()
+    const creator = `${caseItem.createdBy?.firstName || ''} ${caseItem.createdBy?.lastName || ''}`.toLowerCase()
+
+    return title.includes(query) || history.includes(query) || creator.includes(query)
+  })
+
   if (loading) {
     return <div>Loading cases...</div>
   }
 
   return (
     <div>
-      <div className="flex justify-between items-center mb-6">
-        <h2 className="text-2xl font-bold">Manage Cases</h2>
-        <div className="flex gap-2">
-          <button
-            onClick={() => setShowBulkImport(true)}
-            className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
-          >
-            Bulk Import
-          </button>
-          <button
-            onClick={() => setShowCreateForm(!showCreateForm)}
-            className="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700"
-          >
-            {showCreateForm ? 'Cancel' : 'Create New Case'}
-          </button>
+      <div className="mb-6">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-2xl font-bold">Manage Cases</h2>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setShowBulkImport(true)}
+              className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+            >
+              Bulk Import
+            </button>
+            <button
+              onClick={() => setShowCreateForm(!showCreateForm)}
+              className="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+            >
+              {showCreateForm ? 'Cancel' : 'Create New Case'}
+            </button>
+          </div>
         </div>
+
+        {/* Search Bar */}
+        <div className="flex items-center gap-4">
+          <div className="flex-1">
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search cases by title, clinical history, or creator..."
+              className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            />
+          </div>
+          {searchQuery && (
+            <button
+              onClick={() => setSearchQuery('')}
+              className="px-3 py-2 text-sm text-gray-600 hover:text-gray-800"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+        {searchQuery && (
+          <p className="text-sm text-gray-600 mt-2">
+            Found {filteredCases.length} case(s) matching your search.
+          </p>
+        )}
       </div>
 
       {editingCase && (
@@ -549,48 +597,97 @@ export default function CaseManager() {
       )}
 
       <div className="space-y-4">
-        {cases.length === 0 ? (
-          <p className="text-gray-500">No cases yet. Create one above.</p>
+        {filteredCases.length === 0 ? (
+          <p className="text-gray-500">
+            {searchQuery ? 'No cases match your search query.' : 'No cases yet. Create one above.'}
+          </p>
         ) : (
-          cases.map(caseItem => (
-            <div key={caseItem._id} className="bg-white shadow rounded-lg p-6">
-              <div className="flex justify-between items-start mb-4">
-                <div className="flex-1">
-                  <h3 className="text-lg font-semibold">{caseItem.title}</h3>
-                  <p className="text-sm text-gray-600 mt-1">{caseItem.clinicalHistory}</p>
-                </div>
-                <div className="flex gap-2">
+          filteredCases.map(caseItem => (
+            <div key={caseItem._id} className="bg-white shadow rounded-lg overflow-hidden">
+              {/* Case Header - Always Visible */}
+              <div className="p-6">
+                <div className="flex justify-between items-start">
                   <button
-                    onClick={() => startEditCase(caseItem)}
-                    className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm"
+                    onClick={() => toggleCaseExpansion(caseItem._id)}
+                    className="flex-1 text-left flex items-start gap-3 group"
                   >
-                    Edit
+                    <span className="text-gray-600 mt-1 transition-transform group-hover:text-indigo-600">
+                      {expandedCases[caseItem._id] ? '▼' : '▶'}
+                    </span>
+                    <div className="flex-1">
+                      <h3 className="text-lg font-semibold group-hover:text-indigo-600">
+                        {caseItem.title}
+                      </h3>
+                      <p className="text-sm text-gray-600 mt-1 line-clamp-2">
+                        {caseItem.clinicalHistory}
+                      </p>
+                      <div className="mt-2 text-xs text-gray-500">
+                        {caseItem.images.length} image(s) •
+                        Created {new Date(caseItem.createdAt).toLocaleDateString()} by {caseItem.createdBy?.firstName} {caseItem.createdBy?.lastName}
+                      </div>
+                    </div>
                   </button>
-                  <button
-                    onClick={() => deleteCase(caseItem._id)}
-                    className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 text-sm"
-                  >
-                    Delete
-                  </button>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-4 gap-4">
-                {caseItem.images.map((image, index) => (
-                  <div key={index} className="relative group">
-                    <img
-                      src={`/${image.path}`}
-                      alt={image.originalName}
-                      className="w-full h-32 object-cover rounded border"
-                    />
-                    <p className="text-xs text-gray-600 mt-1 truncate">{image.originalName}</p>
+                  <div className="flex gap-2 ml-4">
+                    <button
+                      onClick={() => startEditCase(caseItem)}
+                      className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => deleteCase(caseItem._id)}
+                      className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 text-sm"
+                    >
+                      Delete
+                    </button>
                   </div>
-                ))}
+                </div>
               </div>
 
-              <div className="mt-4 text-sm text-gray-500">
-                Created: {new Date(caseItem.createdAt).toLocaleDateString()} by {caseItem.createdBy?.firstName} {caseItem.createdBy?.lastName}
-              </div>
+              {/* Expanded Content */}
+              {expandedCases[caseItem._id] && (
+                <div className="px-6 pb-6 border-t border-gray-200 pt-4">
+                  <h4 className="text-sm font-semibold text-gray-700 mb-2">Clinical History:</h4>
+                  <p className="text-sm text-gray-600 mb-4 whitespace-pre-wrap">{caseItem.clinicalHistory}</p>
+
+                  {caseItem.discussionPoints && caseItem.discussionPoints.length > 0 && (
+                    <div className="mb-4">
+                      <h4 className="text-sm font-semibold text-gray-700 mb-2">Discussion Points:</h4>
+                      <ul className="list-disc list-inside space-y-1">
+                        {caseItem.discussionPoints.sort((a, b) => a.order - b.order).map((dp, idx) => (
+                          <li key={idx} className="text-sm text-gray-600">{dp.point}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                  <h4 className="text-sm font-semibold text-gray-700 mb-2">Images ({caseItem.images.length}):</h4>
+                  <div className="grid grid-cols-4 gap-4">
+                    {caseItem.images.map((image, index) => (
+                      <div key={index} className="relative group">
+                        <img
+                          src={`/${image.path}`}
+                          alt={image.originalName}
+                          className="w-full h-32 object-cover rounded border"
+                        />
+                        {image.isDicom && (
+                          <span className="absolute top-1 left-1 bg-blue-600 text-white text-xs px-2 py-0.5 rounded">
+                            DICOM
+                          </span>
+                        )}
+                        <p className="text-xs text-gray-600 mt-1 truncate" title={image.originalName}>
+                          {image.originalName}
+                        </p>
+                        {image.description && (
+                          <p className="text-xs text-gray-500 mt-1 line-clamp-2" title={image.description}>
+                            {image.description}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           ))
         )}

--- a/frontend/src/pages/ExamSession.jsx
+++ b/frontend/src/pages/ExamSession.jsx
@@ -37,7 +37,6 @@ export default function ExamSession() {
   const [viewMode, setViewMode] = useState('history') // 'history', 'image', or 'transition'
   const [showTransition, setShowTransition] = useState(false)
   const [dicomThumbnails, setDicomThumbnails] = useState({})
-  const [expandedCases, setExpandedCases] = useState({})
 
   const isExaminer = user.role === 'examiner' || user.role === 'admin'
   const isRunning = status === 'active'
@@ -74,11 +73,6 @@ export default function ExamSession() {
   useEffect(() => {
     if (session?.exam) {
       updateCurrentDisplay(session.exam, currentCaseIndex, currentImageIndex)
-      // Auto-expand the current case in the navigator
-      setExpandedCases(prev => ({
-        ...prev,
-        [currentCaseIndex]: true
-      }))
     }
   }, [currentCaseIndex, currentImageIndex, session?.exam])
 
@@ -399,13 +393,6 @@ export default function ExamSession() {
     const mins = Math.floor(seconds / 60)
     const secs = seconds % 60
     return `${mins}:${secs.toString().padStart(2, '0')}`
-  }
-
-  const toggleCaseExpansion = (caseIndex) => {
-    setExpandedCases(prev => ({
-      ...prev,
-      [caseIndex]: !prev[caseIndex]
-    }))
   }
 
   const isDicomFile = (image) => {
@@ -792,67 +779,23 @@ export default function ExamSession() {
               </button>
             </div>
 
-            {/* Enhanced Case Navigator with Collapsible Image Lists */}
-            {session.exam.cases.length > 0 && (
+            {/* Case Navigator */}
+            {session.exam.cases.length > 1 && (
               <div className="pt-4 border-t border-gray-700">
-                <h4 className="text-sm font-semibold mb-3">All Cases</h4>
-                <div className="space-y-2">
+                <h4 className="text-sm font-semibold mb-3">Jump to Case</h4>
+                <div className="grid grid-cols-3 gap-2">
                   {session.exam.cases.map((caseItem, idx) => (
-                    <div key={idx} className="bg-gray-900 rounded-lg overflow-hidden">
-                      <button
-                        onClick={() => toggleCaseExpansion(idx)}
-                        className={`w-full px-3 py-2 flex items-center justify-between text-left transition-all ${
-                          currentCaseIndex === idx
-                            ? 'bg-blue-600 text-white'
-                            : 'bg-gray-700 hover:bg-gray-600 text-gray-300'
-                        }`}
-                      >
-                        <span className="font-semibold text-sm">
-                          Case {idx + 1}: {caseItem.title}
-                        </span>
-                        <span className="text-xs">
-                          {expandedCases[idx] ? '▼' : '▶'}
-                        </span>
-                      </button>
-
-                      {expandedCases[idx] && (
-                        <div className="p-2 space-y-1">
-                          <button
-                            onClick={() => showHistory(idx)}
-                            className={`w-full px-2 py-1 rounded text-xs flex items-center gap-2 ${
-                              currentCaseIndex === idx && viewMode === 'history'
-                                ? 'bg-blue-500 text-white'
-                                : 'bg-gray-800 hover:bg-gray-700 text-gray-400'
-                            }`}
-                          >
-                            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                            </svg>
-                            Clinical History
-                          </button>
-
-                          {caseItem.images.map((img, imgIdx) => (
-                            <button
-                              key={imgIdx}
-                              onClick={() => navigateToImage(idx, imgIdx + 1)}
-                              className={`w-full px-2 py-1 rounded text-xs flex items-center gap-2 ${
-                                currentCaseIndex === idx && currentImageIndex === imgIdx + 1
-                                  ? 'bg-blue-500 text-white'
-                                  : 'bg-gray-800 hover:bg-gray-700 text-gray-400'
-                              }`}
-                            >
-                              <span className="flex-shrink-0">
-                                {isDicomFile(img) ? '🩻' : '📷'}
-                              </span>
-                              <span className="truncate">
-                                Image {imgIdx + 1}
-                                {img.description && `: ${img.description}`}
-                              </span>
-                            </button>
-                          ))}
-                        </div>
-                      )}
-                    </div>
+                    <button
+                      key={idx}
+                      onClick={() => showHistory(idx)}
+                      className={`px-3 py-2 rounded-lg text-sm font-semibold transition-all ${
+                        currentCaseIndex === idx
+                          ? 'bg-blue-600 text-white shadow-lg'
+                          : 'bg-gray-700 hover:bg-gray-600 text-gray-300'
+                      }`}
+                    >
+                      Case {idx + 1}
+                    </button>
                   ))}
                 </div>
               </div>


### PR DESCRIPTION
Moved the collapsible case navigation feature to the correct location (Manage Cases view) as originally requested.

Changes:
1. Reverted ExamSession.jsx to simple case navigator
   - Removed expandedCases state and toggle function
   - Removed collapsible case list UI
   - Kept DICOM thumbnail fix with file extension fallback
   - Restored original "Jump to Case" grid layout

2. Enhanced CaseManager.jsx with search and collapse
   - Added search bar to filter cases by title, history, or creator
   - Made each case collapsible to show/hide details
   - Collapsed view shows: title, summary, image count, creator
   - Expanded view shows: full clinical history, discussion points, all images
   - DICOM images marked with badge
   - Image descriptions displayed when available
   - Clear button to reset search

This provides better case management while keeping the exam session interface focused on conducting the exam.