### PR TITLE
Fix DICOM single image display issue

### DIFF
--- a/frontend/src/components/admin/CaseManager.jsx
+++ b/frontend/src/components/admin/CaseManager.jsx
@@ -267,6 +267,15 @@ export default function CaseManager() {
     }))
   }
 
+  const isDicomFile = (image) => {
+    if (!image) return false
+    // Check database flag first, fallback to file extension for older files
+    if (image.isDicom === true) return true
+    // Fallback: check file extension
+    const path = image.path || image.filename || ''
+    return path.toLowerCase().endsWith('.dcm') || path.toLowerCase().endsWith('.dicom')
+  }
+
   const filteredCases = cases.filter(caseItem => {
     if (!searchQuery.trim()) return true
 
@@ -670,7 +679,7 @@ export default function CaseManager() {
                           alt={image.originalName}
                           className="w-full h-32 object-cover rounded border"
                         />
-                        {image.isDicom && (
+                        {isDicomFile(image) && (
                           <span className="absolute top-1 left-1 bg-blue-600 text-white text-xs px-2 py-0.5 rounded">
                             DICOM
                           </span>

--- a/frontend/src/pages/ExamSession.jsx
+++ b/frontend/src/pages/ExamSession.jsx
@@ -437,7 +437,11 @@ export default function ExamSession() {
 
   const isDicomFile = (image) => {
     if (!image) return false
-    return image.isDicom === true
+    // Check database flag first, fallback to file extension for older files
+    if (image.isDicom === true) return true
+    // Fallback: check file extension
+    const path = image.path || image.filename || ''
+    return path.toLowerCase().endsWith('.dcm') || path.toLowerCase().endsWith('.dicom')
   }
 
   if (loading) {


### PR DESCRIPTION
The recent commit a562fa9 accidentally removed the file extension fallback for DICOM detection, causing single DICOM images to not be displayed properly.

Changes:
1. Restored isDicomFile() function with .dcm/.dicom extension fallback in ExamSession.jsx
2. Added isDicomFile() helper function to CaseManager.jsx for consistent DICOM detection
3. Both functions now check database isDicom flag first, then fallback to file extension

This ensures:
- Single DICOM files uploaded directly (not from ZIP) are properly recognized
- Older DICOM files without isDicom flag still work
- DICOM badges display correctly in case management
- DICOM viewer loads single images correctly

Fixes issue where single image DICOMs were not being shown in exam sessions.